### PR TITLE
Update codecov-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
         run: npm run coverage
 
       - name: Send coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Generate coverage report of project1 with stack
         uses: ./


### PR DESCRIPTION
Add CODECOV_TOKEN to repository secrets, refer the token from workflow when sending coverage report.